### PR TITLE
Output checksums if ynh_setup_source fails during their verification

### DIFF
--- a/helpers/utils
+++ b/helpers/utils
@@ -167,7 +167,7 @@ ynh_setup_source() {
             || ynh_die --message="$out"
         # Check the control sum
         echo "${src_sum} ${src_filename}" | ${src_sumprg} --check --status \
-            || ynh_die --message="Corrupt source"
+            || ynh_die --message="Corrupt source for ${src_filename}: Expected ${src_sum} but got $(${src_sumprg} ${src_filename} | cut --delimiter=' ' --fields=1)."
     fi
 
     # Keep files to be backup/restored at the end of the helper


### PR DESCRIPTION
## The problem

Output checksums if ynh_setup_source fails during their verification, to help maintainers check if it is a bug or persistent source change.

## Solution

Make the error message a bit more verbose.

## PR Status

Untested in situ, but command works.

## How to test

...
